### PR TITLE
Added a new field 'infoRaw' that preserves formatting

### DIFF
--- a/master_xml.py
+++ b/master_xml.py
@@ -41,7 +41,7 @@ def getRawTooltips(locale):
         tooltipId = split[1].replace("tooltip_","").replace("_description","").replace("\"", "").lstrip("0")
 
         # Remove any quotation marks and new lines.
-        rawTooltips[tooltipId] = split[2].replace("\"", "").replace("\\n", "\n")
+        rawTooltips[tooltipId] = split[2].replace("\"\n", "").replace("\\n", "\n")
 
     return rawTooltips
 

--- a/master_xml.py
+++ b/master_xml.py
@@ -124,7 +124,7 @@ def evaluateInfoData(cards):
                             if abilityValue != None:
                                 cards[cardId]['info'][region] = cards[cardId]['info'][region].replace("{" + key + "}", abilityValue)
 
-            cards[cardId]['infoFormattedXml'][region] = cards[cardId]['info'][region]
+            cards[cardId]['infoRaw'][region] = cards[cardId]['info'][region]
             cards[cardId]['info'][region] = cleanHtml(cards[cardId]['info'][region])
 
 def getCardNames(locale):
@@ -212,7 +212,7 @@ def createCardJson():
 
         if (template.find('Tooltip') != None):
             card['info'] = {}
-            card['infoFormattedXml'] = {}
+            card['infoRaw'] = {}
             for region in LOCALES:
                 # Set to tooltipId for now, we will evaluate after we have looked at every card.
                 card['info'][region] = template.find('Tooltip').attrib['key']

--- a/master_xml.py
+++ b/master_xml.py
@@ -40,8 +40,8 @@ def getRawTooltips(locale):
             continue
         tooltipId = split[1].replace("tooltip_","").replace("_description","").replace("\"", "").lstrip("0")
 
-        # Remove any quotation marks, new lines and html tags.
-        rawTooltips[tooltipId] = cleanHtml(split[2].replace("\"", "").replace("\\n", "\n"))
+        # Remove any quotation marks and new lines.
+        rawTooltips[tooltipId] = split[2].replace("\"", "").replace("\\n", "\n")
 
     return rawTooltips
 
@@ -123,6 +123,9 @@ def evaluateInfoData(cards):
                             abilityValue = getAbilityValue(abilityId, paramName)
                             if abilityValue != None:
                                 cards[cardId]['info'][region] = cards[cardId]['info'][region].replace("{" + key + "}", abilityValue)
+
+            cards[cardId]['infoFormatted'][region] = cards[cardId]['info'][region]
+            cards[cardId]['info'][region] = cleanHtml(cards[cardId]['info'][region])
 
 def getCardNames(locale):
     CARD_NAME_PATH = xml_folder + "cards_" + locale + ".csv"
@@ -209,6 +212,7 @@ def createCardJson():
 
         if (template.find('Tooltip') != None):
             card['info'] = {}
+            card['infoFormatted'] = {}
             for region in LOCALES:
                 # Set to tooltipId for now, we will evaluate after we have looked at every card.
                 card['info'][region] = template.find('Tooltip').attrib['key']

--- a/master_xml.py
+++ b/master_xml.py
@@ -124,7 +124,7 @@ def evaluateInfoData(cards):
                             if abilityValue != None:
                                 cards[cardId]['info'][region] = cards[cardId]['info'][region].replace("{" + key + "}", abilityValue)
 
-            cards[cardId]['infoFormatted'][region] = cards[cardId]['info'][region]
+            cards[cardId]['infoFormattedXml'][region] = cards[cardId]['info'][region]
             cards[cardId]['info'][region] = cleanHtml(cards[cardId]['info'][region])
 
 def getCardNames(locale):
@@ -212,7 +212,7 @@ def createCardJson():
 
         if (template.find('Tooltip') != None):
             card['info'] = {}
-            card['infoFormatted'] = {}
+            card['infoFormattedXml'] = {}
             for region in LOCALES:
                 # Set to tooltipId for now, we will evaluate after we have looked at every card.
                 card['info'][region] = template.find('Tooltip').attrib['key']
@@ -307,7 +307,7 @@ def removeInvalidImages(cards):
 
 def removeUnreleasedCards(cards):
     # A few cards get falsely flagged as released.
-    
+
     # Gaunter's 'Higher than 5' token
     cards['200175']['released'] = False
     # Gaunter's 'Lower than 5' token

--- a/standard-format.json
+++ b/standard-format.json
@@ -14,6 +14,11 @@
       "en-US": "Spawn a Botchling or a Lubberkin.",
       "etc.": "etc.",
     },
+    "infoRaw": {
+      "de-DE": "<keyword=spawn>Generiere</keyword> einen Fehlgeborenen oder einen T\u00f6lpelbold.",
+      "en-US": "<keyword=spawn>Spawn</keyword> a Botchling or a Lubberkin.",
+      "etc.": "etc.",
+    },
     "ingameId": "122101",
     "positions": [
       "Siege"


### PR DESCRIPTION
Implementation of #5 

Example output:

```
"info": {
      "de-DE": "Einsatz: Generiere Einhorn oder Chironex.\n",
      "en-US": "Deploy: Spawn a Unicorn or a Chironex.\n",
      ...
    },
"infoRaw": {
      "de-DE": "<b><keyword=deploy>Einsatz:</keyword></b> <keyword=spawn>Generiere</keyword> Einhorn oder Chironex.\n",
      "en-US": "<b><keyword=deploy>Deploy:</keyword></b> <keyword=spawn>Spawn</keyword> a Unicorn or a Chironex.\n",
      ...
    }
```