### PR TITLE
Feature/keywords

### DIFF
--- a/master_xml.py
+++ b/master_xml.py
@@ -295,6 +295,16 @@ def evaluateTokens(cards):
                         cards.get(tokenId)['released'] = True
                         card['related'].append(tokenId)
 
+def evaluateKeywords(cards):
+    for cardId in cards:
+        card = cards[cardId]
+            card['keywords'] = []
+            # Find all keywords in info string. E.g. find 'spawn' in '<keyword="spawn">'
+            # Can just use en-US here. It doesn't matter, all regions will return the same result.
+            result = re.findall(r'.*?\<keyword=\"(.*?)\"\>.*?', cards[cardId]['infoFormattedXml']['en-US'])
+            for key in result:
+                card['keywords'].append(key)
+
 # If a card is not collectible, we don't have the art for it.
 def removeInvalidImages(cards):
     for cardId in cards:
@@ -382,6 +392,8 @@ cardData = createCardJson()
 evaluateInfoData(cardData)
 # We have to do this as well to catch cards like Botchling, that are explicitly named in the Baron's tooltip.
 evaluateTokens(cardData)
+# After the info text has been evaluated, we can extract the keywords (e.g. deploy).
+evaluateKeywords(cardData)
 removeInvalidImages(cardData)
 removeUnreleasedCards(cardData)
 

--- a/master_xml.py
+++ b/master_xml.py
@@ -298,12 +298,12 @@ def evaluateTokens(cards):
 def evaluateKeywords(cards):
     for cardId in cards:
         card = cards[cardId]
-            card['keywords'] = []
-            # Find all keywords in info string. E.g. find 'spawn' in '<keyword="spawn">'
-            # Can just use en-US here. It doesn't matter, all regions will return the same result.
-            result = re.findall(r'.*?\<keyword=\"(.*?)\"\>.*?', cards[cardId]['infoRaw']['en-US'])
-            for key in result:
-                card['keywords'].append(key)
+        card['keywords'] = []
+        # Find all keywords in info string. E.g. find 'spawn' in '<keyword="spawn">'
+        # Can just use en-US here. It doesn't matter, all regions will return the same result.
+        result = re.findall(r'.*?\<keyword=\"(.*?)\"\>.*?', cards[cardId]['infoRaw']['en-US'])
+        for key in result:
+            card['keywords'].append(key)
 
 # If a card is not collectible, we don't have the art for it.
 def removeInvalidImages(cards):

--- a/master_xml.py
+++ b/master_xml.py
@@ -303,7 +303,7 @@ def evaluateKeywords(cards):
         card['keywords'] = []
         # Find all keywords in info string. E.g. find 'spawn' in '<keyword="spawn">'
         # Can just use en-US here. It doesn't matter, all regions will return the same result.
-        result = re.findall(r'.*?\<keyword=\"(.*?)\"\>.*?', card['infoRaw']['en-US'])
+        result = re.findall(r'.*?\<keyword=(.*?)\>.*?', card['infoRaw']['en-US'])
         for key in result:
             card['keywords'].append(key)
 

--- a/master_xml.py
+++ b/master_xml.py
@@ -301,7 +301,7 @@ def evaluateKeywords(cards):
         if card.get('infoRaw') == None:
             continue
         card['keywords'] = []
-        # Find all keywords in info string. E.g. find 'spawn' in '<keyword="spawn">'
+        # Find all keywords in info string. E.g. find 'spawn' in '<keyword=spawn>'
         # Can just use en-US here. It doesn't matter, all regions will return the same result.
         result = re.findall(r'<keyword=([^>]+)>', card['infoRaw']['en-US'])
         for key in result:

--- a/master_xml.py
+++ b/master_xml.py
@@ -40,8 +40,8 @@ def getRawTooltips(locale):
             continue
         tooltipId = split[1].replace("tooltip_","").replace("_description","").replace("\"", "").lstrip("0")
 
-        # Remove any quotation marks, new lines and html tags.
-        rawTooltips[tooltipId] = cleanHtml(split[2].replace("\"", "").replace("\\n", "\n"))
+        # Remove any quotation marks and new lines.
+        rawTooltips[tooltipId] = split[2].replace("\"", "").replace("\\n", "\n")
 
     return rawTooltips
 
@@ -123,6 +123,9 @@ def evaluateInfoData(cards):
                             abilityValue = getAbilityValue(abilityId, paramName)
                             if abilityValue != None:
                                 cards[cardId]['info'][region] = cards[cardId]['info'][region].replace("{" + key + "}", abilityValue)
+
+            cards[cardId]['infoFormatted'][region] = cards[cardId]['info'][region]
+            cards[cardId]['info'][region] = cleanHtml(cards[cardId]['info'][region])
 
 def getCardNames(locale):
     CARD_NAME_PATH = xml_folder + "cards_" + locale + ".csv"
@@ -209,6 +212,7 @@ def createCardJson():
 
         if (template.find('Tooltip') != None):
             card['info'] = {}
+            card['infoFormatted'] = {}
             for region in LOCALES:
                 # Set to tooltipId for now, we will evaluate after we have looked at every card.
                 card['info'][region] = template.find('Tooltip').attrib['key']

--- a/master_xml.py
+++ b/master_xml.py
@@ -303,7 +303,7 @@ def evaluateKeywords(cards):
         card['keywords'] = []
         # Find all keywords in info string. E.g. find 'spawn' in '<keyword="spawn">'
         # Can just use en-US here. It doesn't matter, all regions will return the same result.
-        result = re.findall(r'.*?\<keyword=(.*?)\>.*?', card['infoRaw']['en-US'])
+        result = re.findall(r'<keyword=([^>]+)>', card['infoRaw']['en-US'])
         for key in result:
             card['keywords'].append(key)
 

--- a/master_xml.py
+++ b/master_xml.py
@@ -298,10 +298,12 @@ def evaluateTokens(cards):
 def evaluateKeywords(cards):
     for cardId in cards:
         card = cards[cardId]
+        if card.get('infoRaw') == None:
+            continue
         card['keywords'] = []
         # Find all keywords in info string. E.g. find 'spawn' in '<keyword="spawn">'
         # Can just use en-US here. It doesn't matter, all regions will return the same result.
-        result = re.findall(r'.*?\<keyword=\"(.*?)\"\>.*?', cards[cardId]['infoRaw']['en-US'])
+        result = re.findall(r'.*?\<keyword=\"(.*?)\"\>.*?', card['infoRaw']['en-US'])
         for key in result:
             card['keywords'].append(key)
 

--- a/master_xml.py
+++ b/master_xml.py
@@ -124,7 +124,7 @@ def evaluateInfoData(cards):
                             if abilityValue != None:
                                 cards[cardId]['info'][region] = cards[cardId]['info'][region].replace("{" + key + "}", abilityValue)
 
-            cards[cardId]['infoFormatted'][region] = cards[cardId]['info'][region]
+            cards[cardId]['infoFormattedXml'][region] = cards[cardId]['info'][region]
             cards[cardId]['info'][region] = cleanHtml(cards[cardId]['info'][region])
 
 def getCardNames(locale):
@@ -212,7 +212,7 @@ def createCardJson():
 
         if (template.find('Tooltip') != None):
             card['info'] = {}
-            card['infoFormatted'] = {}
+            card['infoFormattedXml'] = {}
             for region in LOCALES:
                 # Set to tooltipId for now, we will evaluate after we have looked at every card.
                 card['info'][region] = template.find('Tooltip').attrib['key']
@@ -307,7 +307,7 @@ def removeInvalidImages(cards):
 
 def removeUnreleasedCards(cards):
     # A few cards get falsely flagged as released.
-    
+
     # Gaunter's 'Higher than 5' token
     cards['200175']['released'] = False
     # Gaunter's 'Lower than 5' token


### PR DESCRIPTION
Added a new field `keywords` that lists all of the relevant keywords for a card.

For example Clan Dimun Pirate Captain:

```
"152306": {
    ...
    "infoRaw": {
      "en-US": "<b><keyword=veteran>Veteran</keyword></b> 1.\nWhenever a Unit is <keyword=discard>Discarded</keyword> to your Graveyard, <keyword=boost>Boost</keyword> self by 1 while in your Hand, Deck or on your side of the Board.",
    },
    "keywords": [
      "veteran",
      "discard",
      "boost"
    ],
    "name": {
      "en-US": "Clan Dimun Pirate Captain",
    },
    ...
  },
```