### PR TITLE
Using argparse to pass positional arguments

### DIFF
--- a/master_xml.py
+++ b/master_xml.py
@@ -5,11 +5,20 @@ import os
 import json
 import re
 import time
-from pprint import pprint
+import argparse
 
+from pprint import pprint
 from unidecode import unidecode
 
-PATCH = "v0-9-10"
+
+parser = argparse.ArgumentParser(description="Transform the Gwent card data contained in xml files into a "
+                                             "standardised JSON format.")
+parser.add_argument("inputFolder", help="Folder containing the xml files.")
+parser.add_argument("patch", help="Specifies the Gwent patch version.")
+args = parser.parse_args()
+PATCH = args.patch
+xml_folder = args.inputFolder
+
 # Replace with these values {0} : card id, {1} : variation id, {0} : image size
 IMAGE_URL = "https://firebasestorage.googleapis.com/v0/b/gwent-9e62a.appspot.com/o/images%2F" + PATCH + "%2F{0}%2F{1}%2F{2}.png?alt=media"
 IMAGE_SIZES = ['original', 'high', 'medium', 'low', 'thumbnail']
@@ -327,7 +336,6 @@ def removeUnreleasedCards(cards):
     # Gaunter's 'Lower than 5' token
     cards['200176']['released'] = False
 
-xml_folder = sys.argv[1]
 
 # Add a backslash on the end if it doesn't exist.
 if xml_folder[-1] != "/":

--- a/master_xml.py
+++ b/master_xml.py
@@ -12,7 +12,9 @@ from unidecode import unidecode
 
 
 parser = argparse.ArgumentParser(description="Transform the Gwent card data contained in xml files into a "
-                                             "standardised JSON format.")
+                                             "standardised JSON format.",
+                                 epilog="Usage example:\n./master_xml.py ./pathToXML v0-9-10",
+                                 formatter_class=argparse.RawTextHelpFormatter)
 parser.add_argument("inputFolder", help="Folder containing the xml files.")
 parser.add_argument("patch", help="Specifies the Gwent patch version.")
 args = parser.parse_args()


### PR DESCRIPTION
Patch is now passed to the script as the second argument instead of being defined in the code.
As a side effect, it now have a convenient help command, try passing the ``--help`` flag.

This should complete #6.
The only modification that I made over the proposal was to make patch a positional argument.

Instead of running with the following command:
``./master_xml.py ./pathToXML --patch v0-9-80``
It will be like so:
``./master_xml.py ./pathToXML v0-9-80``

After initially doing as was requested by the issue, I saw that the --help printout was listing patch as optional even when it was required. Bug with argparse or not, [people seems to suggest that parameters starting with ``-`` or ``--`` are usually optional](https://stackoverflow.com/questions/24180527/argparse-required-arguments-listed-under-optional-arguments), so I went with positional for less headache.