### PR TITLE
Mixed up file name in README. Better markdown syntax to see some char…

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ This project contains scripts that transforms the Gwent card data contained in x
     * "cards_en-US.xml" (Repeat for all locales. Rename them so that they are in the format 'xx-XX'. Upper case is important)
     * "tooltips_en-US.xml" (Repeat for all locales. Rename them so that they are in the format 'xx-XX'. Upper case is important)
 2. Rename "cards_jp-JP.xml" and "tooltips_jp-JP.xml" to "cards_ja-JP.xml" and "tooltips_ja-JP.xml" respectively.
-3. In GwentCardTemplates.xml, Find and replace "&" with "&amp;" (ignoring quotes). & is invalid xml.
-4. In GwentCardAbilities.xml, Find and replace "{dmg}" with "dmg" (ignoring quotes).
-5. Run master_xml.py, passing in a folder that contains all the files from step 1.
-    e.g. ./master_xml.py ../raw/
+3. In GwentCardTemplates.xml, Find and replace ``&`` with ``&amp;``. ``&`` is invalid xml.
+4. In GwentTooltips.xml, Find and replace ``{dmg}`` with ``dmg``. ``{`` and ``}`` are invalid xml.
+5. Run master_xml.py, passing in a folder that contains all the files from step 1 with the desired version.
+    e.g. ./master_xml.py ../raw/ v0.9.10
 
 ## Contributing
 Please branch off of master and then submit a PR with your changes. This allows it to be reviewed by other contributors.


### PR DESCRIPTION
…acters that weren't showing. Run example showing that we need the version.
"&amp;" -> ``&amp;``