### PR TITLE
Fix windows error on file read & new output format

### DIFF
--- a/master_xml.py
+++ b/master_xml.py
@@ -4,7 +4,7 @@ import sys
 import os
 import json
 import re
-import time
+from datetime import datetime
 import argparse
 
 from pprint import pprint
@@ -44,7 +44,7 @@ def getRawTooltips(locale):
 
     rawTooltips = {}
 
-    tooltipsFile = open(TOOLTIP_STRINGS_PATH, "r")
+    tooltipsFile = open(TOOLTIP_STRINGS_PATH, "r", encoding="utf8")
     for tooltip in tooltipsFile:
         split = tooltip.split("\";\"")
         if len(split) < 2:
@@ -146,7 +146,7 @@ def getCardNames(locale):
 
     cardNames = {}
 
-    nameFile = open(CARD_NAME_PATH, "r")
+    nameFile = open(CARD_NAME_PATH, "r", encoding="utf8")
     for line in nameFile:
         split = line.split(";")
         if len(split) < 2:
@@ -167,7 +167,7 @@ def getFlavorStrings(locale):
 
     flavorStrings = {}
 
-    nameFile = open(CARD_NAME_PATH, "r")
+    nameFile = open(CARD_NAME_PATH, "r", encoding="utf8")
     for line in nameFile:
         split = line.split(";")
         if len(split) < 2:
@@ -444,5 +444,5 @@ evaluateTokens(cardData)
 evaluateKeywords(cardData)
 removeInvalidImages(cardData)
 removeUnreleasedCards(cardData)
-
-saveJson(str(time.time()) + ".json", cardData)
+# Save under v0-9-19-17.09.05.json if the script is ran on 5 September 2017.
+saveJson(PATCH + "-" + datetime.utcnow().strftime("%y.%m.%d") + ".json", cardData)

--- a/master_xml.py
+++ b/master_xml.py
@@ -4,9 +4,9 @@ import sys
 import os
 import json
 import re
-from datetime import datetime
 import argparse
 
+from datetime import datetime
 from pprint import pprint
 from unidecode import unidecode
 
@@ -444,5 +444,5 @@ evaluateTokens(cardData)
 evaluateKeywords(cardData)
 removeInvalidImages(cardData)
 removeUnreleasedCards(cardData)
-# Save under v0-9-19-17.09.05.json if the script is ran on 5 September 2017.
-saveJson(PATCH + "-" + datetime.utcnow().strftime("%y.%m.%d") + ".json", cardData)
+# Save under v0-9-10_2017-09-05.json if the script is ran on 5 September 2017 with patch v0-9-10.
+saveJson(PATCH + "_" + datetime.utcnow().strftime("%Y-%m-%d") + ".json", cardData)


### PR DESCRIPTION
* Specifying utf8 encoding for all files due to error on windows

* Output json have a new format for its name: patch-YY.MM.DD.json

Run it once to see if things broke.