### PR TITLE
Fix/tokens

### DIFF
--- a/master_xml.py
+++ b/master_xml.py
@@ -308,6 +308,12 @@ def evaluateTokens(cards):
                         cards.get(tokenId)['released'] = True
                         card['related'].append(tokenId)
 
+                for template in ability.iter('TemplateId'):
+                    tokenId = template.attrib['V']
+                    if cards.get(tokenId) != None:
+                        cards.get(tokenId)['released'] = True
+                        card['related'].append(tokenId)
+
 def evaluateKeywords(cards):
     for cardId in cards:
         card = cards[cardId]

--- a/master_xml.py
+++ b/master_xml.py
@@ -310,9 +310,15 @@ def evaluateTokens(cards):
 
                 for template in ability.iter('TemplateId'):
                     tokenId = template.attrib['V']
-                    if cards.get(tokenId) != None:
-                        cards.get(tokenId)['released'] = True
-                        card['related'].append(tokenId)
+                    token = cards.get(tokenId)
+                    if token != None and token.get('info') != None:
+                        valid = True
+                        for region in token['info']:
+                            if token['info'].get(region) == None or token['info'][region] == '':
+                                valid = False
+                        if valid:
+                            token['released'] = True
+                            card['related'].append(tokenId)
 
 def evaluateKeywords(cards):
     for cardId in cards:

--- a/master_xml.py
+++ b/master_xml.py
@@ -291,34 +291,42 @@ def evaluateTokens(cards):
                 # There are several different ways that a template can be referenced.
                 for template in ability.iter('templateId'):
                     tokenId = template.attrib['V']
-                    if cards.get(tokenId) != None:
+                    token = cards.get(tokenId)
+                    if isTokenValid(token):
                         cards.get(tokenId)['released'] = True
                         card['related'].append(tokenId)
 
                 for template in ability.iter('TemplatesFromId'):
                     for token in template.iter('id'):
                         tokenId = token.attrib['V']
-                        if cards.get(tokenId) != None:
+                        token = cards.get(tokenId)
+                        if isTokenValid(token):
                             cards.get(tokenId)['released'] = True
                             card['related'].append(tokenId)
 
                 for template in ability.iter('TransformTemplate'):
                     tokenId = template.attrib['V']
-                    if cards.get(tokenId) != None:
+                    token = cards.get(tokenId)
+                    if isTokenValid(token):
                         cards.get(tokenId)['released'] = True
                         card['related'].append(tokenId)
 
                 for template in ability.iter('TemplateId'):
                     tokenId = template.attrib['V']
                     token = cards.get(tokenId)
-                    if token != None and token.get('info') != None:
-                        valid = True
-                        for region in token['info']:
-                            if token['info'].get(region) == None or token['info'][region] == '':
-                                valid = False
-                        if valid:
-                            token['released'] = True
-                            card['related'].append(tokenId)
+                    if isTokenValid(token):
+                        token['released'] = True
+                        card['related'].append(tokenId)
+
+def isTokenValid(token):
+    if token != None and token.get('info') != None:
+        valid = True
+        for region in token['info']:
+            if token['info'].get(region) == None or token['info'][region] == '':
+                valid = False
+        return valid
+    else:
+        return False
 
 def evaluateKeywords(cards):
     for cardId in cards:

--- a/master_xml.py
+++ b/master_xml.py
@@ -290,7 +290,7 @@ def evaluateTokens(cards):
 
                 # There are several different ways that a template can be referenced.
                 for template in ability.iter('templateId'):
-                    tokenId = ability.find('templateId').attrib['V']
+                    tokenId = template.attrib['V']
                     if cards.get(tokenId) != None:
                         cards.get(tokenId)['released'] = True
                         card['related'].append(tokenId)


### PR DESCRIPTION
Added additional catch for fetching tokens.

Commit [6e38d00](https://github.com/GwentCommunityDevelopers/gwent-data/commit/6e38d007fca23ab6ab7af5033b8fba99a80c87a7) does not change what cards are picked up as tokens, but it does fix an issue that could occur in the future if one ability has multiple tokens.

Picking up the additional token definiton ('TemplateId') gets us the missing Draugir card (#14) but also picks up a load of empty weather cards. I've added additional logic so that we don't mark those as released. I think it is quite sensible that we don't mark a card as released if it's tooltip is empty.